### PR TITLE
Updates to fix the conversion.

### DIFF
--- a/projects/steamer/input.hit
+++ b/projects/steamer/input.hit
@@ -8,13 +8,16 @@
 # Parameters
 xmin = 0.00000e+00  # [m]
 xmax = 2.50000e+01  # [m]
-diff_coeff = 2.00000e+00 # [unit]
-artificial_viscosity = 0.0001 # [unit] this should be small enough but not zero
-source_s = 0.1 # [unit]
+diff_coeff = 2.00000e-9 # [unit]
+artificial_viscosity = 1e-7 # [unit] this should be small enough but not zero
+source_s = .2 # [unit] #no Conv at 125
 rho_l = 1000.0000 # [kg/m^3]
 rho_v = 1.00000   # [kg/m^3]
-mixture_velocity_left = 0.9367 # [m/s]
-vapor_fraction_left = 0.0  # []
+mixture_velocity_left = 0.1 # [m/s]
+vapor_fraction_left = 0  # []
+pts = 101
+
+exit_V = 1e-2
 
 [Mesh]
   [1d]
@@ -35,7 +38,7 @@ vapor_fraction_left = 0.0  # []
     [InitialCondition]
       type = InitialGuess
       bias = ${replace mixture_velocity_left}
-      coefficient = 0
+      coefficient = 100
     []
   []
   [vaporFraction]
@@ -44,7 +47,7 @@ vapor_fraction_left = 0.0  # []
     #initial_condition = 0.5
     [InitialCondition]
       type = InitialGuess
-      bias = 0.5
+      bias = 0.9
       coefficient = 0
     []
   []
@@ -128,7 +131,7 @@ vapor_fraction_left = 0.0  # []
     type = NeumannBC
     variable = mixtureVelocity
     boundary = right
-    value = 0.000843
+    value = ${replace exit_V}
   []
   # Test
   #[exit-mixture-velocity]
@@ -172,7 +175,7 @@ vapor_fraction_left = 0.0  # []
     variable = 'mixtureVelocity vaporFraction'    # output data
     start_point = '${replace xmin} 0 0'
     end_point = '${replace xmax} 0 0'
-    num_points = 51
+    num_points = ${replace pts}
     sort_by = id
   []
 []


### PR DESCRIPTION
I was able to better optimize the void fraction and the error we received by modifying the right neumann BC for velocity (Now a parameter exit_V), the diffusion coefficient, and the source term. By having a very high sourceS I can get to about .998 for a void coefficient, but it introduces about a 130% error margin. This can be reduced to under a % very easily by reducing the sourceS coefficient; however we are only able to achieve about a 95% void fraction at the exit. It is currently being pushed at having a 98% void fraction at the end with a 3.6% error between the computed velocity and the calculated velocity based off the computed void fraction. 